### PR TITLE
fix: query data proof only for submitted extrinsic

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 func main() {
 	// initiates a gin Engine with the default logger and recovery middleware
 	router := gin.Default()
-
 	// Initialise Avail DA client
 	avail, err := NewAvailDA()
 	if err != nil {


### PR DESCRIPTION
- fix: data proof query endpoint and response struct
- opt: query proofs only for submitted extrinsic and not all of them
- refactor: remove legacy code